### PR TITLE
Fix Safari 9

### DIFF
--- a/download.js
+++ b/download.js
@@ -106,8 +106,9 @@
 				return true;
 			}
 
-			if(typeof safari !=="undefined" ){ // handle non-a[download] safari as best we can:
-				url="data:"+url.replace(/^data:([\w\/\-\+]+)/, u);
+			// handle non-a[download] safari as best we can:
+			if(/(Version)\/(\d+)\.(\d+)(?:\.(\d+))?.*Safari\//.test(navigator.userAgent)) {
+				url=url.replace(/^data:([\w\/\-\+]+)/, u);
 				if(!window.open(url)){ // popup blocked, offer direct download:
 					if(confirm("Displaying New Document\n\nUse Save As... to download, then click back to return to this page.")){ location.href=url; }
 				}


### PR DESCRIPTION
Removing the `data:` part from blob url makes it load again in a new tab.
Haven't tested how it still works in Safari 8 though.
