### PR TITLE
Support data urls with missing mime-types

### DIFF
--- a/download.js
+++ b/download.js
@@ -61,7 +61,7 @@
 
 
 		//go ahead and download dataURLs right away
-		if(/^data\:[\w+\-]+\/[\w+\-\.]+[,;]/.test(payload)){
+		if(/^data:([\w+-]+\/[\w+.-]+)?[,;]/.test(payload)){
 		
 			if(payload.length > (1024*1024*1.999) && myBlob !== toString ){
 				payload=dataUrlToBlob(payload);


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc2397 it should be valid to have a data url without a mime-type.  This small change updates the 'dataURL' checking regular expression to support those types of data url.