### PR TITLE
fixed Issue when download in IE, when charset is defined in data uri

### DIFF
--- a/download.js
+++ b/download.js
@@ -87,7 +87,8 @@
 		function dataUrlToBlob(strUrl) {
 			var parts= strUrl.split(/[:;,]/),
 			type= parts[1],
-			decoder= parts[2] == "base64" ? atob : decodeURIComponent,
+			indexDecoder = strUrl.indexOf("charset")>0 ? 3: 2,
+			decoder= parts[indexDecoder] == "base64" ? atob : decodeURIComponent,
 			binData= decoder( parts.pop() ),
 			mx= binData.length,
 			i= 0,


### PR DESCRIPTION
When you try to download a file in IE, using a data uri with charset defined, the file is corrupted.

