### PR TITLE
Stop anchor click propagation

### DIFF
--- a/download.js
+++ b/download.js
@@ -106,6 +106,10 @@
 				anchor.className = "download-js-link";
 				anchor.innerHTML = "downloading...";
 				anchor.style.display = "none";
+ 				anchor.addEventListener('click', function(e) {
+ 					e.stopPropagation();
+ 					this.removeEventListener('click', arguments.callee);
+ 				});
 				document.body.appendChild(anchor);
 				setTimeout(function() {
 					anchor.click();


### PR DESCRIPTION
Fixes #54 by calling `MouseEvent.stopPropagation()` inside a click event handler for the invisible anchor element. The handler removes itself once executed.