### PR TITLE
Replace spare symbols with CDNJS version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # download
-========
+[![CDNJS](https://img.shields.io/cdnjs/v/downloadjs.svg)](https://cdnjs.com/libraries/downloadjs)
 
 ## Summary
 ---------


### PR DESCRIPTION
The badge shows the latest lib version on CDNJS and gives a link of it.