### PR TITLE
Error if the script is linked with "use strict";

### DIFF
--- a/download.js
+++ b/download.js
@@ -107,9 +107,9 @@
 				anchor.className = "download-js-link";
 				anchor.innerHTML = "downloading...";
 				anchor.style.display = "none";
- 				anchor.addEventListener('click', function(e) {
+ 				var EL=anchor.addEventListener('click', function(e) {
  					e.stopPropagation();
- 					this.removeEventListener('click', arguments.callee);
+ 					this.removeEventListener('click', EL);
  				});
 				document.body.appendChild(anchor);
 				setTimeout(function() {


### PR DESCRIPTION
if the script is included with "use strict", Chrome throws an error at this point:

Uncaught TypeError: 'caller', 'callee', and 'arguments' properties may not be accessed on strict mode functions or the arguments objects for calls to them

If you save the reference in a variable and used everything is ok.